### PR TITLE
fix: wine creation form not saving new values between steps

### DIFF
--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,4 +1,5 @@
 import datetime
+import json
 from http import HTTPStatus
 
 import pytest
@@ -844,4 +845,29 @@ def test_wine_edit_replace_front_image(client, user, wine_factory, clear_image_f
     assertRedirects(
         response=r, expected_url=reverse("wine-detail", kwargs={"pk": wine.pk})
     )
-    assert WineImage.objects.filter(wine=wine, image_type=ImageType.FRONT).count() == 1
+
+
+@pytest.mark.django_db
+def test_wine_create_new_open_field_value_preserved_across_steps(client, user):
+    """New values entered in OpenMultipleChoiceField must appear in TomSelect items
+    on the re-rendered form so the browser keeps them selected on subsequent steps."""
+    client.force_login(user)
+    size = Size.objects.get(name=0.75)
+    r = client.get(reverse("wine-add"))
+    initial = r.context_data["form"].initial.copy()
+    initial.update(
+        {
+            "name": "Merlot",
+            "wine_type": "RE",
+            "size": size.pk,
+            "country": "DE",
+            "grapes": ["tom_new_optChardonnay"],
+            "form_step": 0,
+        }
+    )
+    r = client.post(reverse("wine-add"), data=initial)
+    assert r.status_code == HTTPStatus.OK
+    form = r.context_data["form"]
+    assert form.data["form_step"] == 1
+    tom_config = json.loads(form.fields["grapes"].widget.attrs["data-tom_config"])
+    assert "Chardonnay" in tom_config.get("items", [])

--- a/wine_cellar/apps/wine/forms.py
+++ b/wine_cellar/apps/wine/forms.py
@@ -104,13 +104,24 @@ class WineFormPostCleanMixin:
 
         for name in fields_to_update:
             value = self.cleaned_data.get(name)
-            if not value:
+            field = self.fields.get(name)
+            new_values = (
+                list(field.new_values)
+                if isinstance(field, OpenMultipleChoiceField)
+                else []
+            )
+
+            if not value and not new_values:
                 continue
 
             if isinstance(value, list) or isinstance(value, QuerySet):
                 items = [v.pk if hasattr(v, "pk") else v for v in value]
-            else:
+            elif value:
                 items = [value.pk if hasattr(value, "pk") else value]
+            else:
+                items = []
+
+            items.extend(new_values)
 
             create = name in (
                 "grapes",


### PR DESCRIPTION
When adding select fields which accept new values (grapes, attributes, food pairings, source, size) the form would forget those when pressing continue. This means that potentially some of the values for those fields got lost when you added a wine to your cellar.