### PR TITLE
fix: use environment variables for SECRET_KEY and DEBUG (CWE-798, CWE-489)

### DIFF
--- a/wine_cellar/conf/settings.py
+++ b/wine_cellar/conf/settings.py
@@ -10,6 +10,7 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/5.0/ref/settings/
 """
 
+import os
 from pathlib import Path
 
 from django.utils.csp import CSP
@@ -26,10 +27,10 @@ VERSION = __version__
 # See https://docs.djangoproject.com/en/5.0/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = "django-insecure-9_c29b95eghgc@yx6lyuiz3*h#oy7*zh8*vb36d1cwe)b4%v0d"
+SECRET_KEY = os.environ.get("SECRET_KEY", "django-insecure-9_c29b95eghgc@yx6lyuiz3*h#oy7*zh8*vb36d1cwe)b4%v0d")
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+DEBUG = os.environ.get("DEBUG", "True").lower() in ("true", "1", "yes")
 
 
 ALLOWED_HOSTS = []


### PR DESCRIPTION
## Summary

Two security issues in `wine_cellar/conf/settings.py`:

1. **`SECRET_KEY`** was hardcoded with a `django-insecure-` prefix key (CWE-798). Anyone with source access can forge sessions, CSRF tokens, and password reset tokens.
2. **`DEBUG = True`** was unconditionally enabled (CWE-489). Running in production with DEBUG=True leaks stack traces, SQL queries, settings, and enables the Django debug console.

## Fix

- `SECRET_KEY` now reads from `os.environ.get("SECRET_KEY")` with the `django-insecure-` key as a dev-only fallback
- `DEBUG` now reads from `os.environ.get("DEBUG")` — defaults to `True` only when unset

## 📚 Understanding This Vulnerability

### Что это?
Zhestko zakodirovannye klyuchi v iskhodnom kode (CWE-798) + aktivnyj otladochnyj kod v nastrojkakh (CWE-489).

### Почему это важно?
Django `SECRET_KEY` podpisyvaet sessionnye kuki, CSRF-tokeny i tokeny sbrosa parolya. Znaya SECRET_KEY, zloumyshlennik mozhet poddelat sessiyu administratora. `DEBUG=True` raskryvaet vnutrennie puti, SQL-zaprosy i mozhet privesti k vypolneniyu koda cherez debug-konsol.

### Когда проявляется?
settings.py, config.py, primery koda, testovye fikstury s realnymi dannymi.

### Как исправить правильно?
`os.getenv()` + `.env` + `.gitignore`. Nikakikh parolej v repozitorii.

### 🧠 Аналогия
> Klyuch ot kvartiry pod kovrikom + dver naraspashku. Dazhe esli nikto ne vidit — odnazhdy kto-to proverit.

### 📖 Дополнительно
- [Django Deployment Checklist](https://docs.djangoproject.com/en/5.0/howto/deployment/checklist/)
- [CWE-798: Use of Hard-coded Credentials](https://cwe.mitre.org/data/definitions/798.html)
- [CWE-489: Active Debug Code](https://cwe.mitre.org/data/definitions/489.html)

---
🐛 Found by [GSC](https://github.com/poliakarmai/gsc) — ponimaj kod, a ne prinimaj.