### PR TITLE
fix: default email verification for regular sign-ups is now optional

### DIFF
--- a/.env.prod-sample
+++ b/.env.prod-sample
@@ -28,6 +28,7 @@ DJANGO_ENABLE_SIGNUPS=False
 DJANGO_ENABLE_SOCIAL_SIGNUPS=True
 # DJANGO_ACCOUNT_EMAIL_VERIFICATION and DJANGO_SOCIALACCOUNT_EMAIL_VERIFICATION accept
 # "mandatory", "optional" or "none" - see https://docs.allauth.org/en/latest/socialaccount/configuration.html
+# If signups are enabled, email verification is strongly recommended. 
 DJANGO_ACCOUNT_EMAIL_VERIFICATION=optional
 DJANGO_SOCIALACCOUNT_EMAIL_VERIFICATION=optional
 DJANGO_SOCIALACCOUNT_EMAIL_AUTHENTICATION=False

--- a/docs/usage/users.md
+++ b/docs/usage/users.md
@@ -41,7 +41,7 @@ ENABLE_SIGNUPS = True
 Once enabled, a registration page will be available for new users to sign up without admin intervention.
 
 ???+ Info
-    Signups will require an email server to be configured, otherwise users won't be able to verify their email. In case your admin account
+    Signups will don't require email verification by default, however it's strongly adviced to make it mandatory. For that an email server needs to be configured, otherwise users won't be able to verify their email. In case your admin account
     doesn't have an email configured, add one first.
 
 ???+ Info


### PR DESCRIPTION
BREAKING CHANGE: email verification for regular sign-ups defaults to optional now. If you currently allow signups and want email verification change it to `mandatory` in your `.env.prod`.